### PR TITLE
Return none if no subject set

### DIFF
--- a/gmail_wrapper/entities.py
+++ b/gmail_wrapper/entities.py
@@ -79,7 +79,7 @@ class Message:
 
     @property
     def subject(self):
-        return self.headers["Subject"]
+        return self.headers.get("Subject")
 
     @property
     def date(self):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -35,6 +35,11 @@ class TestMessage:
         )
         mocked_get_raw_message.assert_called_once_with(raw_incomplete_message["id"])
 
+    def test_it_return_none_if_no_subject_header(self, client, raw_complete_message):
+        del raw_complete_message["payload"]["headers"][2]
+        message = Message(client, raw_complete_message)
+        assert message.subject is None
+
     def test_get_labels(
         self, mocker, raw_complete_message, client, raw_incomplete_message
     ):


### PR DESCRIPTION
When the message has no subject, instead of returning `null` as JSON property, Gmail returns no `Subject` key at all.

This change will return `None` to our users when there is no subject header set.