### PR TITLE
Deal with missing parts

### DIFF
--- a/gmail_wrapper/entities.py
+++ b/gmail_wrapper/entities.py
@@ -89,9 +89,10 @@ class Message:
 
     @property
     def attachments(self):
+        parts = self._payload.get("parts")
         return [
             Attachment(self.id, self._client, part)
-            for part in self._payload.get("parts")
+            for part in (parts if parts else [])
             if part["filename"]
         ]
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -64,6 +64,13 @@ class TestMessage:
             ]
         )
 
+    def test_it_returns_empty_list_if_no_attachments(
+        self, client, raw_complete_message
+    ):
+        raw_complete_message["payload"]["parts"] = None
+        complete_message = Message(client, raw_complete_message)
+        assert complete_message.attachments == []
+
     def test_it_modifies_a_message(
         self, mocker, client, raw_incomplete_message, raw_complete_message
     ):


### PR DESCRIPTION
As the [Gmail API](https://googleapis.github.io/google-api-python-client/docs/dyn/gmail_v1.users.messages.html) states, there are cases where the `parts` key will be absent:

> For non- container MIME message part types, such as text/plain, this field is empty. For more information, see [RFC 1521](https://www.ietf.org/rfc/rfc1521.txt).

It was causing a `'NoneType' object is not iterable` error when trying to generate attachments without this field. Behavior now is to return an empty array, so it becomes more abstract.