### PR TITLE
Filter attachments without ID

### DIFF
--- a/gmail_wrapper/entities.py
+++ b/gmail_wrapper/entities.py
@@ -112,7 +112,7 @@ class Message:
         return [
             Attachment(self.id, self._client, part)
             for part in (parts if parts else [])
-            if part["filename"]
+            if part["filename"] and part["body"] and part["body"].get("attachmentId")
         ]
 
     def modify(self, add_labels=None, remove_labels=None):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -65,6 +65,22 @@ class TestMessage:
             ]
         )
 
+    def test_it_does_not_generate_attachment_objects_for_attachments_without_id(
+        self, client, raw_complete_message
+    ):
+        complete_message = Message(client, raw_complete_message)
+        raw_complete_message["payload"]["parts"].append(
+            {
+                "body": {"size": 0, "data": ""},
+                "filename": "invalid.pdf",
+                "partId": "BB710",
+                "mimeType": "application/pdf",
+            }
+        )
+        assert len(complete_message.attachments) == 1
+        assert complete_message.attachments[0].id
+        assert complete_message.attachments[0].filename != "invalid.pdf"
+
     def test_it_returns_empty_list_if_no_attachments(
         self, client, raw_complete_message
     ):


### PR DESCRIPTION
For some weird reason, there are attachments returned by Gmail that have the following structure:

```json
{"size": 0, "data": ""}
```

This is a problem since it doesn't have a `attachmentId` so we can properly get its contents.

This PR filters theses cases on `Message` entity so this kind of attachment is not returned to the library user.