### PR TITLE
Support less seen versions of Message-ID

### DIFF
--- a/gmail_wrapper/entities.py
+++ b/gmail_wrapper/entities.py
@@ -91,7 +91,7 @@ class Message:
         While self.id is the user-bound id of the message, self.message_id
         is the global id of the message, valid for every user on the thread.
         """
-        return self.headers.get("Message-ID")
+        return self.headers.get("Message-ID", self.headers.get("Message-Id"))
 
     @property
     def thread_id(self):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -115,6 +115,20 @@ class TestMessage:
             raw_complete_message["id"], add_labels=None, remove_labels=["INBOX"]
         )
 
+    def test_message_id_property(self, client, raw_complete_message):
+        message = Message(client, raw_complete_message)
+        assert (
+            message.message_id
+            == "<BY5PR15MB353717D866FC27FEE4DB4EC7F77E0@BY5PR15MB3537.namprd15.prod.outlook.com>"
+        )
+        raw_complete_message["payload"]["headers"][3]["name"] = "Message-Id"
+        assert (
+            message.message_id
+            == "<BY5PR15MB353717D866FC27FEE4DB4EC7F77E0@BY5PR15MB3537.namprd15.prod.outlook.com>"
+        )
+        raw_complete_message["payload"]["headers"][3]["name"] = "Invalid"
+        assert message.message_id is None
+
 
 class TestAttachment:
     def test_it_has_basic_properties_without_additional_fetch(


### PR DESCRIPTION
Some providers, although very rare ones, use the header `Message-Id`, instead of the official one, `Message-ID`.

This PR aims to address that, supporting these less used providers.