### PR TITLE
Support recursive parts for attachment lookup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,9 +52,9 @@ def raw_complete_message():
             "parts": [
                 {
                     "body": {
-                        "data": "I am caught up in a meeting. Can you run an urgent errand for me?",
+                        "data": "I am Dr. Bakare Tunde, the cousin of Nigerian Astronaut, Air Force Major Abacha Tunde. He was the first African in space when he made a secret flight to the Salyut 6 space station in 1979.",
                         "attachmentId": "CCX456",
-                        "size": 65,
+                        "size": 188,
                     },
                     "mimeType": "text/plain",
                     "partId": "BB789",
@@ -66,10 +66,29 @@ def raw_complete_message():
                     "partId": "BB790",
                     "filename": "fox.txt",
                 },
+                {
+                    "body": {"size": 0},
+                    "mimeType": "multipart/mixed",
+                    "partId": "BB791",
+                    "parts": [
+                        {
+                            "body": {"data": "someRandomDataHere", "size": 18},
+                            "mimeType": "text/html",
+                            "partId": "BB791.0",
+                            "filename": "",
+                        },
+                        {
+                            "body": {"attachmentId": "CCX458", "size": 95},
+                            "mimeType": "application/pdf",
+                            "partId": "BB791.1",
+                            "filename": "tigers.pdf",
+                        }
+                    ],
+                },
             ],
         },
-        "snippet": "I am caught up in a meeting. Can you run an urgent errand for me?",
-        "sizeEstimate": 125,
+        "snippet": "I am Dr. Bakare Tunde, the cousin of Nigerian Astronaut, Air Force Major Abacha Tunde.",
+        "sizeEstimate": 361,
         "threadId": "AA121212",
         "labelIds": ["phishing"],
         "id": "123AAB",

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -77,9 +77,11 @@ class TestMessage:
                 "mimeType": "application/pdf",
             }
         )
-        assert len(complete_message.attachments) == 1
+        assert len(complete_message.attachments) == 2
         assert complete_message.attachments[0].id
-        assert complete_message.attachments[0].filename != "invalid.pdf"
+        assert complete_message.attachments[0].filename == "fox.txt"
+        assert complete_message.attachments[1].id
+        assert complete_message.attachments[1].filename == "tigers.pdf"
 
     def test_it_returns_empty_list_if_no_attachments(
         self, client, raw_complete_message


### PR DESCRIPTION
Since a `part` can not only be an attachment, but also **contai attachments**, we should then lookup it recursively to get all of them.

For example:

```json
"parts": [
      {
        "partId": "0",
        "mimeType": "text/plain",
        "filename": "",
        "headers": [
          {
            "name": "Content-Transfer-Encoding",
            "value": "quoted-printable"
          },
          {
            "name": "Content-Type",
            "value": "text/plain; charset=us-ascii"
          }
        ],
        "body": {
          "size": 302,
          "data": "anonymized"
        }
      },
      {
        "partId": "1",
        "mimeType": "multipart/mixed",
        "filename": "",
        "headers": [
          {
            "name": "Content-Type",
            "value": "multipart/mixed; boundary=\\"
          }
        ],
        "body": {
          "size": 0
        },
        "parts": [
          {
            "partId": "1.0",
            "mimeType": "text/html",
            "filename": "",
            "headers": [
              {
                "name": "Content-Transfer-Encoding",
                "value": "quoted-printable"
              },
              {
                "name": "Content-Type",
                "value": "text/html; charset=us-ascii"
              }
            ],
            "body": {
              "size": 1082,
              "data": "anonymized"
            }
          },
          {
            "partId": "1.1",
            "mimeType": "application/pdf",
            "filename": "MyDocument.pdf",
            "headers": [
              {
                "name": "Content-Disposition",
                "value": "inline; filename=\\"
              },
              {
                "name": "Content-Type",
                "value": "application/pdf; x-unix-mode=0644; name=\\"
              },
              {
                "name": "Content-Transfer-Encoding",
                "value": "base64"
              }
            ],
            "body": {
              "attachmentId": "anonymized",
              "size": 2313101
            }
          },
          {
            "partId": "1.2",
            "mimeType": "text/html",
            "filename": "",
            "headers": [
              {
                "name": "Content-Transfer-Encoding",
                "value": "7bit"
              },
              {
                "name": "Content-Type",
                "value": "text/html; charset=us-ascii"
              }
            ],
            "body": {
              "size": 799,
              "data": "anonymized"
            }
          }
        ]
      }
    ]
```