### PR TITLE
Add support to replying messages using reply-to header

### DIFF
--- a/gmail_wrapper/entities.py
+++ b/gmail_wrapper/entities.py
@@ -86,6 +86,10 @@ class Message:
         return self.headers.get("From")
 
     @property
+    def reply_to(self):
+        return self.headers.get("Reply-To")
+
+    @property
     def message_id(self):
         """
         While self.id is the user-bound id of the message, self.message_id
@@ -130,11 +134,13 @@ class Message:
             self.id, add_labels=add_labels, remove_labels=remove_labels
         )
 
-    def reply(self, html_content):
+    def reply(self, html_content, use_reply_to=True):
+        to = self.reply_to if (self.reply_to and use_reply_to) else self.from_address
+
         return self._client.send(
             subject=f"Re:{self.subject}",
             html_content=html_content,
-            to=self.from_address,
+            to=to,
             references=[self.message_id],
             in_reply_to=[self.message_id],
             thread_id=self.thread_id,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -291,32 +291,3 @@ class TestSend:
         )
         assert isinstance(sent_message, Message)
         assert sent_message.id == raw_complete_message["id"]
-
-
-class TestReply:
-    def test_it_returns_the_sent_message(self, client, mocker, raw_complete_message):
-        message_to_reply = Message(client, raw_complete_message)
-        expected_message_to_be_sent = {"id": "114ADC", "internalDate": "1566398665"}
-        mocked_send_raw_message = mocker.patch(
-            "gmail_wrapper.client.GmailClient.send_raw",
-            return_value=expected_message_to_be_sent,
-        )
-        sent_message = message_to_reply.reply(
-            "The quick brown fox jumps over the lazy dog"
-        )
-        mocked_send_raw_message.assert_called_once_with(
-            "Re:Urgent errand",
-            "The quick brown fox jumps over the lazy dog",
-            "john@doe.com",
-            None,
-            None,
-            [
-                "<BY5PR15MB353717D866FC27FEE4DB4EC7F77E0@BY5PR15MB3537.namprd15.prod.outlook.com>"
-            ],
-            [
-                "<BY5PR15MB353717D866FC27FEE4DB4EC7F77E0@BY5PR15MB3537.namprd15.prod.outlook.com>"
-            ],
-            "AA121212",
-        )
-        assert isinstance(sent_message, Message)
-        assert sent_message.id == expected_message_to_be_sent["id"]


### PR DESCRIPTION
If the message has a `Reply-To` header, then use it instead of the "from" address.

The developer can still force using the from address setting `use_reply_to=False`.