### PR TITLE
Add long description content type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     name="gmail-wrapper",
     description="Because scrapping Gmail data doesn't have to be a pain",
     long_description=readme,
+    long_description_content_type="text/markdown",
     author="Loadsmart Inc.",
     author_email="engineering@loadsmart.com",
     url="https://github.com/loadsmart/gmail-wrapper",


### PR DESCRIPTION
Fixes

```
HTTPError: 400 Bad Request from https://test.pypi.org/legacy/
The description failed to render in the default format of reStructuredText. See https://test.pypi.org/help/#description-content-type for more information.
```
