### PR TITLE
Make coveralls optional for forked branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,15 +21,12 @@ jobs:
           name: gen-coverage
           command: |
             make coverage
-            if [ $COVERALLS_REPO_TOKEN ]; then
-              coveralls
-            fi
 
       - run:
           name: upload-coverage
           command: |
             if [ $COVERALLS_REPO_TOKEN ]; then
-              bash <(curl -s https://codecov.io/bash)
+              coveralls
             fi
 
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,17 @@ jobs:
           name: gen-coverage
           command: |
             make coverage
-            coveralls
+            if [ $COVERALLS_REPO_TOKEN ]; then
+              coveralls
+            fi
 
       - run:
           name: upload-coverage
           command: |
-            bash <(curl -s https://codecov.io/bash)
+            if [ $COVERALLS_REPO_TOKEN ]; then
+              bash <(curl -s https://codecov.io/bash)
+            fi
+
   release:
     docker:
       - image: circleci/python:3.7


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

This PR makes the coveralls step of the Circle CI build optional so that external contributors can open PRs from forked branches.